### PR TITLE
Refactored plugin to use Actions - Command Pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
       <version>7.0.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+      <version>7.0.0</version>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>

--- a/src/main/java/dev/hugog/minecraft/wonderquests/actions/AbstractAction.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/actions/AbstractAction.java
@@ -1,0 +1,11 @@
+package dev.hugog.minecraft.wonderquests.actions;
+
+import lombok.AllArgsConstructor;
+import org.bukkit.command.CommandSender;
+
+@AllArgsConstructor
+public abstract class AbstractAction implements Action {
+
+  protected CommandSender sender;
+
+}

--- a/src/main/java/dev/hugog/minecraft/wonderquests/actions/Action.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/actions/Action.java
@@ -1,0 +1,7 @@
+package dev.hugog.minecraft.wonderquests.actions;
+
+public interface Action {
+
+  boolean execute();
+
+}

--- a/src/main/java/dev/hugog/minecraft/wonderquests/actions/concrete/CreateQuestAction.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/actions/concrete/CreateQuestAction.java
@@ -1,0 +1,109 @@
+package dev.hugog.minecraft.wonderquests.actions.concrete;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+import dev.hugog.minecraft.wonderquests.actions.AbstractAction;
+import dev.hugog.minecraft.wonderquests.data.dtos.QuestDto;
+import dev.hugog.minecraft.wonderquests.data.services.QuestsService;
+import dev.hugog.minecraft.wonderquests.interaction.InteractiveSession;
+import dev.hugog.minecraft.wonderquests.interaction.InteractiveSessionBuilder;
+import dev.hugog.minecraft.wonderquests.interaction.InteractiveSessionFormatter;
+import dev.hugog.minecraft.wonderquests.interaction.InteractiveSessionManager;
+import dev.hugog.minecraft.wonderquests.interaction.InteractiveStep;
+import dev.hugog.minecraft.wonderquests.language.Messaging;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class CreateQuestAction extends AbstractAction {
+
+  private final Messaging messaging;
+  private final InteractiveSessionManager sessionManager;
+  private final QuestsService questsService;
+
+  @Inject
+  public CreateQuestAction(@Assisted CommandSender sender, Messaging messaging,
+      InteractiveSessionManager sessionManager, QuestsService questsService) {
+    super(sender);
+    this.messaging = messaging;
+    this.sessionManager = sessionManager;
+    this.questsService = questsService;
+  }
+
+  @Override
+  public boolean execute() {
+
+    if (!(sender instanceof Player player)) {
+      sender.sendMessage("Only players can create quests.");
+      return false;
+    }
+
+    QuestDto questDto = new QuestDto();
+
+    InteractiveSessionFormatter formatter = InteractiveSessionFormatter.builder(player, messaging)
+        .title(messaging.getLocalizedRawMessage("commands.quest.create.interaction.title"))
+        .summary(messaging.getLocalizedRawMessage("commands.quest.create.summary"))
+        .cancelMessage(messaging.getLocalizedRawMessage("commands.quest.create.interaction.cancel"))
+        .finalMessage(messaging.getLocalizedRawMessage("commands.quest.create.success"))
+        .build();
+
+    InteractiveStep questNameStep = InteractiveStep.builder()
+        .message(messaging.getLocalizedChatNoPrefix("commands.quest.create.interaction.name"))
+        .inputVerification(input -> input.length() > 3)
+        .onValidInput(questDto::setName)
+        .onInvalidInput(input -> System.out.println("Invalid input: " + input))
+        .build();
+
+    InteractiveStep questDescriptionStep = InteractiveStep.builder()
+        .message(
+            messaging.getLocalizedChatNoPrefix("commands.quest.create.interaction.description"))
+        .inputVerification(input -> input.length() > 3)
+        .onValidInput(questDto::setDescription)
+        .onInvalidInput(input -> System.out.println("Invalid input: " + input))
+        .build();
+
+    InteractiveStep questOpeningMessageStep = InteractiveStep.builder()
+        .message(
+            messaging.getLocalizedChatNoPrefix("commands.quest.create.interaction.opening_message"))
+        .inputVerification(input -> input.length() > 3)
+        .onValidInput(questDto::setOpeningMsg)
+        .onInvalidInput(input -> System.out.println("Invalid input: " + input))
+        .build();
+
+    InteractiveStep questClosingMessageStep = InteractiveStep.builder()
+        .message(
+            messaging.getLocalizedChatNoPrefix("commands.quest.create.interaction.closing_message"))
+        .inputVerification(input -> input.length() > 3)
+        .onValidInput(questDto::setClosingMsg)
+        .onInvalidInput(input -> System.out.println("Invalid input: " + input))
+        .build();
+
+    InteractiveStep questTimeLimitStep = InteractiveStep.builder()
+        .message(messaging.getLocalizedChatNoPrefix("commands.quest.create.interaction.time_limit"))
+        .inputVerification(input -> input.matches("\\d+") && Integer.parseInt(input) >= 0)
+        .onValidInput(input -> System.out.println("Valid input: " + input))
+        .onInvalidInput(input -> System.out.println("Invalid input: " + input))
+        .build();
+
+    InteractiveSession interactiveSession = new InteractiveSessionBuilder(player, sessionManager)
+        .withSessionFormatter(formatter)
+        .withStep(questNameStep)
+        .withStep(questDescriptionStep)
+        .withStep(questOpeningMessageStep)
+        .withStep(questClosingMessageStep)
+        .withStep(questTimeLimitStep)
+        .withSessionEndCallback(() -> questsService.createNewQuest(questDto))
+        .build();
+
+    boolean couldStartSession = interactiveSession.startSession();
+
+    if (!couldStartSession) {
+      player.sendMessage(
+          messaging.getLocalizedChatWithPrefix("interaction.error.already_in_progress"));
+      return false;
+    }
+
+    return true;
+
+  }
+
+}

--- a/src/main/java/dev/hugog/minecraft/wonderquests/commands/AbstractPluginCommand.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/commands/AbstractPluginCommand.java
@@ -1,6 +1,5 @@
 package dev.hugog.minecraft.wonderquests.commands;
 
-import dev.hugog.minecraft.wonderquests.language.Messaging;
 import org.bukkit.command.CommandSender;
 
 /**
@@ -14,15 +13,15 @@ public abstract class AbstractPluginCommand implements PluginCommand {
 
   protected CommandSender sender;
   protected String[] args;
-  protected Messaging messaging;
-  protected Object[] dependencies;
+  protected CommandDependencies dependencies;
+  protected Object[] extraDependencies;
 
-  public AbstractPluginCommand(CommandSender sender, String[] args, Messaging messaging,
-      Object... dependencies) {
+  public AbstractPluginCommand(CommandSender sender, String[] args,
+      CommandDependencies commandDependencies, Object... extraDependencies) {
     this.sender = sender;
     this.args = args;
-    this.messaging = messaging;
-    this.dependencies = dependencies;
+    this.dependencies = commandDependencies;
+    this.extraDependencies = extraDependencies;
   }
 
 }

--- a/src/main/java/dev/hugog/minecraft/wonderquests/commands/BukkitCommandExecutor.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/commands/BukkitCommandExecutor.java
@@ -10,21 +10,21 @@ import org.jetbrains.annotations.NotNull;
  * <h3>Bukkit Command Executor</h3>
  * <h4>Represents the default Bukkit command executor.</h4>
  * <br>
- * <p>The class receives commands from the chat and redirects them to the {@link CommandInvoker} if
+ * <p>The class receives commands from the chat and redirects them to the {@link CommandResolver} if
  * they are commands from this plugin.</p>
  *
- * <p>The {@link CommandInvoker}, part of the <strong>Commander Pattern</strong>, will create a new
+ * <p>The {@link CommandResolver}, part of the <strong>Commander Pattern</strong>, will create a new
  * {@link PluginCommand} instance based on the command's label and execute the command.</p>
  *
- * <p>See {@link CommandInvoker#setPluginCommand(String, CommandSender, String[])}.</p>
+ * <p>See {@link CommandResolver#setPluginCommand(String, CommandSender, String[])}.</p>
  */
 public class BukkitCommandExecutor implements CommandExecutor {
 
-  private final CommandInvoker commandInvoker;
+  private final CommandResolver commandResolver;
 
   @Inject
-  public BukkitCommandExecutor(CommandInvoker commandInvoker) {
-    this.commandInvoker = commandInvoker;
+  public BukkitCommandExecutor(CommandResolver commandResolver) {
+    this.commandResolver = commandResolver;
   }
 
   @Override
@@ -40,8 +40,8 @@ public class BukkitCommandExecutor implements CommandExecutor {
       return true;
     }
 
-    commandInvoker.setPluginCommand(args[0], commandSender, args);
-    return commandInvoker.executeCommand();
+    commandResolver.setPluginCommand(args[0], commandSender, args);
+    return commandResolver.executeCommand();
 
   }
 

--- a/src/main/java/dev/hugog/minecraft/wonderquests/commands/CommandDependencies.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/commands/CommandDependencies.java
@@ -1,0 +1,27 @@
+package dev.hugog.minecraft.wonderquests.commands;
+
+import com.google.inject.Inject;
+import dev.hugog.minecraft.wonderquests.injection.factories.ActionsFactory;
+import dev.hugog.minecraft.wonderquests.language.Messaging;
+import lombok.Getter;
+
+/**
+ * <h3>Command Dependencies</h3>
+ * <h4>Represents the common dependencies of {@link PluginCommand} classes.</h4>
+ * <br>
+ * <p>It is used to inject dependencies that are used by all commands or at least by most of
+ * them such as messaging and actions dependencies.</p>
+ */
+@Getter
+public class CommandDependencies {
+
+  private final Messaging messaging;
+  private final ActionsFactory actionsFactory;
+
+  @Inject
+  private CommandDependencies(Messaging messaging, ActionsFactory actionsFactory) {
+    this.messaging = messaging;
+    this.actionsFactory = actionsFactory;
+  }
+
+}

--- a/src/main/java/dev/hugog/minecraft/wonderquests/commands/CommandResolver.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/commands/CommandResolver.java
@@ -2,34 +2,27 @@ package dev.hugog.minecraft.wonderquests.commands;
 
 import com.google.inject.Inject;
 import dev.hugog.minecraft.wonderquests.commands.concrete.CreateQuestCommand;
-import dev.hugog.minecraft.wonderquests.data.services.QuestsService;
-import dev.hugog.minecraft.wonderquests.interaction.InteractiveSessionManager;
-import dev.hugog.minecraft.wonderquests.language.Messaging;
 import org.bukkit.command.CommandSender;
 
 /**
  * <h3>Command Invoker</h3>
  * <h4>Invokes a {@link PluginCommand},i.e., a concrete command.</h4>
  * <br>
- * <p>The {@link CommandInvoker} is part of the <strong>Commander Pattern</strong> and is used to
+ * <p>The {@link CommandResolver} is part of the <strong>Commander Pattern</strong> and is used to
  * invoke a {@link PluginCommand} based on the command label.</p>
  *
  * <p>Depending on the command, this class can also inject the necessary command's
  * dependencies.</p>
  */
-public class CommandInvoker {
+public class CommandResolver {
 
   private PluginCommand pluginCommand;
 
-  private final Messaging messaging;
-  private final InteractiveSessionManager interactiveSessionManager;
-  private final QuestsService questsService;
+  private final CommandDependencies dependencies;
 
   @Inject
-  public CommandInvoker(Messaging messaging, InteractiveSessionManager interactiveSessionManager, QuestsService questsService) {
-    this.messaging = messaging;
-    this.interactiveSessionManager = interactiveSessionManager;
-    this.questsService = questsService;
+  public CommandResolver(CommandDependencies dependencies) {
+    this.dependencies = dependencies;
   }
 
   public boolean executeCommand() {
@@ -48,7 +41,7 @@ public class CommandInvoker {
    */
   public void setPluginCommand(String commandLabel, CommandSender sender, String[] args) {
     if (commandLabel.equals("create")) {
-      this.pluginCommand = new CreateQuestCommand(sender, args, messaging, interactiveSessionManager, questsService);
+      this.pluginCommand = new CreateQuestCommand(sender, args, dependencies);
     } else {
       this.pluginCommand = null;
     }

--- a/src/main/java/dev/hugog/minecraft/wonderquests/injection/BasicBinderModule.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/injection/BasicBinderModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
 import dev.hugog.minecraft.wonderquests.WonderQuests;
 import dev.hugog.minecraft.wonderquests.data.repositories.AbstractDataRepository;
@@ -12,6 +13,7 @@ import dev.hugog.minecraft.wonderquests.data.repositories.QuestObjectivesReposit
 import dev.hugog.minecraft.wonderquests.data.repositories.QuestRequirementsRepository;
 import dev.hugog.minecraft.wonderquests.data.repositories.QuestRewardsRepository;
 import dev.hugog.minecraft.wonderquests.data.repositories.QuestsRepository;
+import dev.hugog.minecraft.wonderquests.injection.factories.ActionsFactory;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -25,6 +27,9 @@ public class BasicBinderModule extends AbstractModule {
 
   @Override
   protected void configure() {
+
+    FactoryModuleBuilder factoryModuleBuilder = new FactoryModuleBuilder();
+    install(factoryModuleBuilder.build(ActionsFactory.class));
 
     this.bind(WonderQuests.class).toInstance(plugin);
     this.bind(Logger.class).annotatedWith(Names.named("bukkitLogger"))

--- a/src/main/java/dev/hugog/minecraft/wonderquests/injection/factories/ActionsFactory.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/injection/factories/ActionsFactory.java
@@ -1,0 +1,10 @@
+package dev.hugog.minecraft.wonderquests.injection.factories;
+
+import dev.hugog.minecraft.wonderquests.actions.concrete.CreateQuestAction;
+import org.bukkit.command.CommandSender;
+
+public interface ActionsFactory {
+
+  CreateQuestAction buildCreateQuestAction(CommandSender sender);
+
+}


### PR DESCRIPTION
### Description:

In this plugin, it will be common to do some actions differently. For example, I may want to create a quest using `/quests create` command; however, I may also want to create it using a clickable Component. In both cases, the logic to create the quest is the same; the only difference is how this logic is initiated.

In order to be able to use the same logic for different initiators without copying code, I have created "Actions" that implement the [Command Pattern](https://refactoring.guru/design-patterns/command) to allow this code re-utilization.

I have also refactored the existing commands to move their logic to actions working with this new paradigm.