### PR TITLE
Implemented support for completed quests information

### DIFF
--- a/src/main/java/dev/hugog/minecraft/wonderquests/actions/implementation/ShowAvailableQuestsAction.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/actions/implementation/ShowAvailableQuestsAction.java
@@ -19,8 +19,12 @@ public class ShowAvailableQuestsAction extends AbstractAction<Boolean> {
 
   @Override
   public Boolean execute() {
-    // TODO: Check if sender is a player
-    guiFactory.buildAvailableQuestsGui((Player) sender).open();
+
+    if (!(sender instanceof Player player)) {
+      return false;
+    }
+
+    guiFactory.buildAvailableQuestsGui(player).open();
     return false;
   }
 

--- a/src/main/java/dev/hugog/minecraft/wonderquests/data/services/CompletedQuestsService.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/data/services/CompletedQuestsService.java
@@ -1,0 +1,34 @@
+package dev.hugog.minecraft.wonderquests.data.services;
+
+import com.google.inject.Inject;
+import dev.hugog.minecraft.wonderquests.data.dtos.CompletedQuestDto;
+import dev.hugog.minecraft.wonderquests.data.models.CompletedQuestModel;
+import dev.hugog.minecraft.wonderquests.data.repositories.CompletedQuestRepository;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class CompletedQuestsService {
+
+  private final CompletedQuestRepository completedQuestRepository;
+
+  @Inject
+  public CompletedQuestsService(CompletedQuestRepository completedQuestRepository) {
+    this.completedQuestRepository = completedQuestRepository;
+  }
+
+  public CompletableFuture<Boolean> addCompletedQuest(CompletedQuestDto completedQuestDto) {
+    return completedQuestRepository.insert(completedQuestDto.toModel())
+        .thenApply(Objects::nonNull);
+  }
+
+  public CompletableFuture<Set<CompletedQuestDto>> getCompletedQuestByPlayer(UUID playerId) {
+    return completedQuestRepository.findAllByPlayer(playerId)
+        .thenApply(completedQuestModels -> completedQuestModels.stream()
+            .map(CompletedQuestModel::toDto)
+            .collect(Collectors.toSet()));
+  }
+
+}

--- a/src/main/java/dev/hugog/minecraft/wonderquests/data/services/QuestsService.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/data/services/QuestsService.java
@@ -79,7 +79,7 @@ public class QuestsService {
         .thenApply(Optional::isPresent);
   }
 
-  public CompletableFuture<Set<QuestDto>> getAvailableQuests(Player player) {
+  public CompletableFuture<Set<QuestDto>> getPotentialAvailableQuests(Player player) {
     return questsRepository.findAll().thenApply(questModels -> questModels.stream()
         .map(QuestModel::toDto)
         .filter(quest -> playerHasRequirements(player, quest))

--- a/src/main/java/dev/hugog/minecraft/wonderquests/guis/AvailableQuestsGui.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/guis/AvailableQuestsGui.java
@@ -5,8 +5,8 @@ import com.google.inject.assistedinject.Assisted;
 import dev.hugog.minecraft.wonderquests.WonderQuests;
 import dev.hugog.minecraft.wonderquests.concurrency.ConcurrencyHandler;
 import dev.hugog.minecraft.wonderquests.data.dtos.QuestDto;
-import dev.hugog.minecraft.wonderquests.data.services.QuestsService;
 import dev.hugog.minecraft.wonderquests.injection.factories.ActionsFactory;
+import dev.hugog.minecraft.wonderquests.mediators.QuestsMediator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -25,7 +25,7 @@ public class AvailableQuestsGui implements Gui {
 
   private final Player player;
   private final WonderQuests plugin;
-  private final QuestsService questsService;
+  private final QuestsMediator questsMediator;
   private final GuiManager guiManager;
   private final ConcurrencyHandler concurrencyHandler;
 
@@ -36,14 +36,14 @@ public class AvailableQuestsGui implements Gui {
 
   @Inject
   public AvailableQuestsGui(@Assisted Player player, WonderQuests plugin, GuiManager guiManager,
-      ConcurrencyHandler concurrencyHandler, QuestsService questsService,
+      ConcurrencyHandler concurrencyHandler, QuestsMediator questsMediator,
       ActionsFactory actionsFactory) {
 
     this.player = player;
     this.plugin = plugin;
     this.guiManager = guiManager;
     this.concurrencyHandler = concurrencyHandler;
-    this.questsService = questsService;
+    this.questsMediator = questsMediator;
     this.actionsFactory = actionsFactory;
 
   }
@@ -55,7 +55,7 @@ public class AvailableQuestsGui implements Gui {
 
     this.inventory = plugin.getServer().createInventory(player, 27, guiTitle);
 
-    return questsService.getAvailableQuests(player).thenAccept((quests) -> {
+    return questsMediator.getAvailableQuests(player).thenAccept((quests) -> {
       quests.forEach((quest) -> inventory.addItem(buildItemFromQuest(quest)));
     });
 

--- a/src/main/java/dev/hugog/minecraft/wonderquests/mediators/QuestsMediator.java
+++ b/src/main/java/dev/hugog/minecraft/wonderquests/mediators/QuestsMediator.java
@@ -5,9 +5,11 @@ import com.google.inject.name.Named;
 import dev.hugog.minecraft.wonderquests.WonderQuests;
 import dev.hugog.minecraft.wonderquests.concurrency.ConcurrencyHandler;
 import dev.hugog.minecraft.wonderquests.data.dtos.ActiveQuestDto;
+import dev.hugog.minecraft.wonderquests.data.dtos.CompletedQuestDto;
 import dev.hugog.minecraft.wonderquests.data.dtos.QuestDto;
 import dev.hugog.minecraft.wonderquests.data.keys.PlayerQuestKey;
 import dev.hugog.minecraft.wonderquests.data.services.ActiveQuestsService;
+import dev.hugog.minecraft.wonderquests.data.services.CompletedQuestsService;
 import dev.hugog.minecraft.wonderquests.data.services.QuestsService;
 import dev.hugog.minecraft.wonderquests.events.ActiveQuestUpdateEvent;
 import dev.hugog.minecraft.wonderquests.events.QuestUpdateType;
@@ -24,18 +26,20 @@ public class QuestsMediator {
   private final ConcurrencyHandler concurrencyHandler;
   private final QuestsService questsService;
   private final ActiveQuestsService activeQuestsService;
+  private final CompletedQuestsService completedQuestsService;
   private final WonderQuests plugin;
   private final Messaging messaging;
 
   @Inject
   public QuestsMediator(@Named("bukkitLogger") Logger logger,
       ConcurrencyHandler concurrencyHandler, QuestsService questsService,
-      ActiveQuestsService activeQuestsService,
+      ActiveQuestsService activeQuestsService, CompletedQuestsService completedQuestsService,
       WonderQuests plugin, Messaging messaging) {
     this.logger = logger;
     this.concurrencyHandler = concurrencyHandler;
     this.questsService = questsService;
     this.activeQuestsService = activeQuestsService;
+    this.completedQuestsService = completedQuestsService;
     this.plugin = plugin;
     this.messaging = messaging;
   }
@@ -92,46 +96,53 @@ public class QuestsMediator {
 
   public void handleQuestCompletion(Player player, ActiveQuestDto activeQuest) {
 
-    activeQuestsService.removeQuest(
-        new PlayerQuestKey(player.getUniqueId(), activeQuest.getQuestId())).thenRun(() -> {
+    activeQuestsService.removeQuest(new PlayerQuestKey(player.getUniqueId(), activeQuest.getQuestId()))
+        .thenRun(() -> {
 
-      giveQuestRewardsToPlayer(player, activeQuest.getQuestId());
+          // Call the ActiveQuestUpdateEvent to update the signs, for example.
+          concurrencyHandler.run(() -> plugin.getServer().getPluginManager()
+                  .callEvent(
+                      new ActiveQuestUpdateEvent(player, QuestUpdateType.COMPLETED, activeQuest)),
+              true);
 
-      questsService.getQuestById(activeQuest.getQuestId()).thenAccept((quest) -> {
+          giveQuestRewardsToPlayer(player, activeQuest.getQuestId());
 
-        // The quest doesn't exist
-        if (quest.isEmpty()) {
-          return;
-        }
+          completedQuestsService.addCompletedQuest(new CompletedQuestDto(
+              player.getUniqueId(),
+              activeQuest.getQuestId()
+          ));
 
-        concurrencyHandler.run(() -> plugin.getServer().getPluginManager()
-                .callEvent(new ActiveQuestUpdateEvent(player, QuestUpdateType.COMPLETED, activeQuest)),
-            true);
+          questsService.getQuestById(activeQuest.getQuestId()).thenAccept((quest) -> {
 
-        QuestDto questDto = quest.get();
+            // The quest doesn't exist
+            if (quest.isEmpty()) {
+              return;
+            }
 
-        player.sendMessage(messaging.getLocalizedChatWithPrefix(
-            "quests.completion.message",
-            Component.text(questDto.getName()))
-        );
+            QuestDto questDto = quest.get();
 
-        player.showTitle(Title.title(
-                messaging.getLocalizedRawMessage("quests.completion.message.title")
-                    .color(NamedTextColor.GOLD),
-                messaging.getLocalizedRawMessage(
-                        "quests.completion.message.subtitle",
-                        Component.text(questDto.getName(), NamedTextColor.GREEN)
-                    )
-                    .color(NamedTextColor.GRAY)
-            )
-        );
+            player.sendMessage(messaging.getLocalizedChatWithPrefix(
+                "quests.completion.message",
+                Component.text(questDto.getName()))
+            );
 
-        player.sendMessage(messaging.getQuestMessagePrefix()
-            .append(Component.text(quest.get().getClosingMsg())));
+            player.showTitle(Title.title(
+                    messaging.getLocalizedRawMessage("quests.completion.message.title")
+                        .color(NamedTextColor.GOLD),
+                    messaging.getLocalizedRawMessage(
+                            "quests.completion.message.subtitle",
+                            Component.text(questDto.getName(), NamedTextColor.GREEN)
+                        )
+                        .color(NamedTextColor.GRAY)
+                )
+            );
 
-      });
+            player.sendMessage(messaging.getQuestMessagePrefix()
+                .append(Component.text(quest.get().getClosingMsg())));
 
-    });
+          });
+
+        });
 
   }
 


### PR DESCRIPTION
### Description:

This PR introduces the feature with which the plugin will store all the completed quests in the database. These completed quests are then used to filter the available quests for the user - if a user completed a quest, it should not show again for him to complete it.